### PR TITLE
Feature/project manipulation

### DIFF
--- a/src/main/kotlin/data/repo/ProjectNotFoundException.kt
+++ b/src/main/kotlin/data/repo/ProjectNotFoundException.kt
@@ -1,0 +1,6 @@
+package org.damascus.data.repo
+
+import java.util.*
+
+class ProjectNotFoundException(projectId: UUID) :
+    RuntimeException("Project with ID $projectId not found")

--- a/src/main/kotlin/data/repo/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/data/repo/ProjectRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package org.damascus.data.repo
+
+import kotlinx.datetime.LocalDateTime
+import logic.model.Project
+import org.damascus.data.DataSource
+import org.damascus.logic.repository.ProjectRepository
+import java.util.*
+
+class ProjectNotFoundException(projectId: UUID) :
+    RuntimeException("Project with ID $projectId not found")
+
+class ProjectRepositoryImpl(private val projectDataSource: DataSource<Project>): ProjectRepository {
+
+    override fun create(project: Project) : Boolean{
+        return true
+    }
+    override fun update(projectId: UUID, project: Project) : Boolean{
+        return true
+    }
+    override fun delete(projectId: UUID) : Boolean{
+        return true
+    }
+    override fun exists(projectId: UUID) : Boolean{
+        return true
+    }
+    override fun get(projectId: UUID) : Project{
+        return Project(
+            id = UUID.randomUUID(),
+            name = "Project",
+            assignedMatesIds = mutableListOf(UUID.randomUUID()),
+            creationDate = LocalDateTime(2024, 5, 1, 12, 0)
+        )
+
+    }
+    override fun getAll(): List<Project> {
+        return listOf()
+    }
+    override fun assignMate(projectId: UUID, mateId: UUID): Boolean{
+        return true
+    }
+    override fun unassignMate(projectId: UUID, mateId: UUID): Boolean{
+        return true
+    }
+
+}

--- a/src/main/kotlin/data/repo/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/data/repo/ProjectRepositoryImpl.kt
@@ -1,83 +1,46 @@
 package org.damascus.data.repo
 
 
-
 import logic.model.Project
 import org.damascus.data.DataSource
 import org.damascus.logic.repository.ProjectRepository
 import java.util.*
 
 
-class ProjectNotFoundException(projectId: UUID) :
-    RuntimeException("Project with ID $projectId not found")
-
-class ProjectRepositoryImpl(private val projectDataSource: DataSource<Project>) : ProjectRepository {
+class ProjectRepositoryImpl(private val dataSource: DataSource<Project>) : ProjectRepository {
 
     override fun create(project: Project): Boolean {
-        val existingProjects = projectDataSource.read()
-        if (existingProjects.any { it.id == project.id }) return false
-        projectDataSource.write(project)
+        if (dataSource.read().any { it.id == project.id }) return false
+        dataSource.write(project)
         return true
     }
 
     override fun update(projectId: UUID, project: Project): Boolean {
-        val existingProjects = projectDataSource.read()
-        if (existingProjects.none { it.id == projectId }) return false
-        projectDataSource.update(projectId, project)
+        if (dataSource.read().none { it.id == projectId }) return false
+        dataSource.update(projectId, project)
         return true
     }
 
     override fun delete(projectId: UUID): Boolean {
-        val existingProjects = projectDataSource.read()
-        if (existingProjects.none { it.id == projectId }) return false
-        projectDataSource.delete(projectId)
+        if (dataSource.read().none { it.id == projectId }) return false
+        dataSource.delete(projectId)
         return true
     }
 
     override fun exists(projectId: UUID): Boolean {
-        return projectDataSource.read().any { it.id == projectId }
+        return dataSource.read().any { it.id == projectId }
     }
 
     override fun get(projectId: UUID): Project {
-        return projectDataSource.read().firstOrNull { it.id == projectId }
+        return dataSource.read().firstOrNull { it.id == projectId }
             ?: throw ProjectNotFoundException(projectId)
     }
 
     override fun getAll(): List<Project> {
-        return projectDataSource.read()
+        return dataSource.read()
     }
 
-    override fun assignMate(projectId: UUID, mateId: UUID): Boolean {
-        val existingProjects = projectDataSource.read()
-
-        val project = existingProjects.firstOrNull { it.id == projectId }
-            ?: return false
-
-        if (project.assignedMatesIds.contains(mateId))
-            return false
-
-        val updatedProject = project.copy(
-            assignedMatesIds = project.assignedMatesIds.toMutableList().apply { add(mateId) }
-        )
-
-        projectDataSource.update(project.id, updatedProject)
-        return true
-    }
-
-    override fun unassignMate(projectId: UUID, mateId: UUID): Boolean {
-        val existingProjects = projectDataSource.read()
-
-        val project = existingProjects.firstOrNull { it.id == projectId }
-            ?: return false
-
-        if (!project.assignedMatesIds.contains(mateId))
-            return false
-
-        val updatedProject = project.copy(
-            assignedMatesIds = project.assignedMatesIds.toMutableList().apply { remove(mateId) }
-        )
-
-        projectDataSource.update(project.id, updatedProject)
-        return true
+    override fun getAllProjectsByMateId(mateId: UUID): List<Project> {
+        return dataSource.read().filter { mateId in it.assignedMatesIds }
     }
 }

--- a/src/main/kotlin/data/repo/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/data/repo/ProjectRepositoryImpl.kt
@@ -1,45 +1,83 @@
 package org.damascus.data.repo
 
-import kotlinx.datetime.LocalDateTime
+
+
 import logic.model.Project
 import org.damascus.data.DataSource
 import org.damascus.logic.repository.ProjectRepository
 import java.util.*
 
+
 class ProjectNotFoundException(projectId: UUID) :
     RuntimeException("Project with ID $projectId not found")
 
-class ProjectRepositoryImpl(private val projectDataSource: DataSource<Project>): ProjectRepository {
+class ProjectRepositoryImpl(private val projectDataSource: DataSource<Project>) : ProjectRepository {
 
-    override fun create(project: Project) : Boolean{
+    override fun create(project: Project): Boolean {
+        val existingProjects = projectDataSource.read()
+        if (existingProjects.any { it.id == project.id }) return false
+        projectDataSource.write(project)
         return true
     }
-    override fun update(projectId: UUID, project: Project) : Boolean{
+
+    override fun update(projectId: UUID, project: Project): Boolean {
+        val existingProjects = projectDataSource.read()
+        if (existingProjects.none { it.id == projectId }) return false
+        projectDataSource.update(projectId, project)
         return true
     }
-    override fun delete(projectId: UUID) : Boolean{
+
+    override fun delete(projectId: UUID): Boolean {
+        val existingProjects = projectDataSource.read()
+        if (existingProjects.none { it.id == projectId }) return false
+        projectDataSource.delete(projectId)
         return true
     }
-    override fun exists(projectId: UUID) : Boolean{
-        return true
+
+    override fun exists(projectId: UUID): Boolean {
+        return projectDataSource.read().any { it.id == projectId }
     }
-    override fun get(projectId: UUID) : Project{
-        return Project(
-            id = UUID.randomUUID(),
-            name = "Project",
-            assignedMatesIds = mutableListOf(UUID.randomUUID()),
-            creationDate = LocalDateTime(2024, 5, 1, 12, 0)
+
+    override fun get(projectId: UUID): Project {
+        return projectDataSource.read().firstOrNull { it.id == projectId }
+            ?: throw ProjectNotFoundException(projectId)
+    }
+
+    override fun getAll(): List<Project> {
+        return projectDataSource.read()
+    }
+
+    override fun assignMate(projectId: UUID, mateId: UUID): Boolean {
+        val existingProjects = projectDataSource.read()
+
+        val project = existingProjects.firstOrNull { it.id == projectId }
+            ?: return false
+
+        if (project.assignedMatesIds.contains(mateId))
+            return false
+
+        val updatedProject = project.copy(
+            assignedMatesIds = project.assignedMatesIds.toMutableList().apply { add(mateId) }
         )
 
-    }
-    override fun getAll(): List<Project> {
-        return listOf()
-    }
-    override fun assignMate(projectId: UUID, mateId: UUID): Boolean{
-        return true
-    }
-    override fun unassignMate(projectId: UUID, mateId: UUID): Boolean{
+        projectDataSource.update(project.id, updatedProject)
         return true
     }
 
+    override fun unassignMate(projectId: UUID, mateId: UUID): Boolean {
+        val existingProjects = projectDataSource.read()
+
+        val project = existingProjects.firstOrNull { it.id == projectId }
+            ?: return false
+
+        if (!project.assignedMatesIds.contains(mateId))
+            return false
+
+        val updatedProject = project.copy(
+            assignedMatesIds = project.assignedMatesIds.toMutableList().apply { remove(mateId) }
+        )
+
+        projectDataSource.update(project.id, updatedProject)
+        return true
+    }
 }

--- a/src/main/kotlin/logic/repository/ProjectRepository.kt
+++ b/src/main/kotlin/logic/repository/ProjectRepository.kt
@@ -1,0 +1,16 @@
+package org.damascus.logic.repository
+
+import logic.model.Project
+import java.util.UUID
+
+interface ProjectRepository {
+    fun create(project: Project): Boolean
+    fun update(projectId: UUID, project: Project): Boolean
+    fun delete(projectId: UUID): Boolean
+    fun exists(projectId: UUID): Boolean
+    fun get(projectId: UUID): Project
+    fun getAll(): List<Project>
+    fun assignMate(projectId: UUID, mateId: UUID): Boolean
+    fun unassignMate(projectId: UUID, mateId: UUID): Boolean
+
+}

--- a/src/main/kotlin/logic/repository/ProjectRepository.kt
+++ b/src/main/kotlin/logic/repository/ProjectRepository.kt
@@ -10,7 +10,5 @@ interface ProjectRepository {
     fun exists(projectId: UUID): Boolean
     fun get(projectId: UUID): Project
     fun getAll(): List<Project>
-    fun assignMate(projectId: UUID, mateId: UUID): Boolean
-    fun unassignMate(projectId: UUID, mateId: UUID): Boolean
-
+    fun getAllProjectsByMateId(mateId: UUID): List<Project>
 }

--- a/src/main/kotlin/logic/usecase/ModifyMateAssignmentUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ModifyMateAssignmentUseCase.kt
@@ -1,0 +1,32 @@
+package org.damascus.logic.usecase
+
+import org.damascus.logic.repository.ProjectRepository
+import java.util.*
+
+class ModifyMateAssignmentUseCase(
+    private val repository: ProjectRepository
+) {
+
+    operator fun invoke(
+        projectId: UUID,
+        mateId: UUID,
+        shouldAssign: Boolean
+    ): Boolean {
+        val project = try {
+            repository.get(projectId)
+        } catch (e: Exception) {
+            return false
+        }
+
+        val mates = project.assignedMatesIds.toMutableList()
+        val alreadyAssigned = mateId in mates
+
+        if (shouldAssign && alreadyAssigned) return false
+        if (!shouldAssign && !alreadyAssigned) return false
+
+        if (shouldAssign) mates.add(mateId) else mates.remove(mateId)
+
+        val updatedProject = project.copy(assignedMatesIds = mates)
+        return repository.update(projectId, updatedProject)
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/CheckProjectExistsUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/CheckProjectExistsUseCase.kt
@@ -1,0 +1,10 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import org.damascus.logic.repository.ProjectRepository
+import java.util.UUID
+
+class CheckProjectExistsUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(projectId: UUID): Boolean {
+        return repository.exists(projectId)
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/CreateProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/CreateProjectUseCase.kt
@@ -1,0 +1,11 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+
+class CreateProjectUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(project: Project): Boolean {
+        if (repository.exists(project.id)) return false
+        return repository.create(project)
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/DeleteProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/DeleteProjectUseCase.kt
@@ -1,0 +1,10 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import org.damascus.logic.repository.ProjectRepository
+import java.util.UUID
+
+class DeleteProjectUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(projectId: UUID): Boolean {
+        return repository.delete(projectId)
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/GetAllProjectsByMateIdUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/GetAllProjectsByMateIdUseCase.kt
@@ -1,0 +1,11 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+import java.util.UUID
+
+class GetAllProjectsByMateIdUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(mateId: UUID): List<Project> {
+        return repository.getAllProjectsByMateId(mateId)
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/GetAllProjectsUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/GetAllProjectsUseCase.kt
@@ -1,0 +1,10 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+
+class GetAllProjectsUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(): List<Project> {
+        return repository.getAll()
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/GetProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/GetProjectUseCase.kt
@@ -1,0 +1,11 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+import java.util.UUID
+
+class GetProjectUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(projectId: UUID): Project {
+        return repository.get(projectId)
+    }
+}

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/ModifyMateAssignmentUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/ModifyMateAssignmentUseCase.kt
@@ -1,4 +1,4 @@
-package org.damascus.logic.usecase
+package org.damascus.logic.usecase.ProjectUseCase
 
 import org.damascus.logic.repository.ProjectRepository
 import java.util.*

--- a/src/main/kotlin/logic/usecase/ProjectUseCase/UpdateProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecase/ProjectUseCase/UpdateProjectUseCase.kt
@@ -1,0 +1,11 @@
+package org.damascus.logic.usecase.ProjectUseCase
+
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+import java.util.UUID
+
+class UpdateProjectUseCase(private val repository: ProjectRepository) {
+    operator fun invoke(projectId: UUID, project: Project): Boolean {
+        return repository.update(projectId, project)
+    }
+}

--- a/src/test/kotlin/data/repo/ProjectRepositoryImplTest.kt
+++ b/src/test/kotlin/data/repo/ProjectRepositoryImplTest.kt
@@ -1,0 +1,238 @@
+
+package data.repo
+
+import io.mockk.mockk
+import logic.model.Project
+import logic.model.Mate
+import org.damascus.data.DataSource
+import org.damascus.data.repo.ProjectRepositoryImpl
+import com.google.common.truth.Truth.assertThat
+import kotlinx.datetime.LocalDateTime
+import org.damascus.data.repo.ProjectNotFoundException
+import org.junit.jupiter.api.Test
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.verify
+import org.damascus.logic.model.Role
+import org.junit.jupiter.api.BeforeEach
+import java.util.*
+
+class ProjectRepositoryImplTest {
+
+
+ lateinit var dataSource: DataSource<Project>
+ lateinit var repo: ProjectRepositoryImpl
+
+ @BeforeEach
+ fun setup() {
+  dataSource = mockk(relaxed = true)
+  repo = ProjectRepositoryImpl(dataSource)
+ }
+
+ @Test
+ fun `should return false when create an existing project`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  justRun { dataSource.write(any<Project>()) }
+  val result = repo.create(project)
+  assertThat(result).isFalse()
+  verify(exactly = 0) { dataSource.write(any<Project>()) }
+ }
+
+ @Test
+ fun `should return true when create a new project`() {
+  val newProject = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf()
+  justRun { dataSource.write(newProject) }
+  val result = repo.create(newProject)
+  assertThat(result).isTrue()
+  verify { dataSource.write(newProject) }
+ }
+
+ @Test
+ fun `should return false when update a non existing project`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf()
+  val result = repo.update(project.id, project)
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return true when update an existing project`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  justRun { dataSource.update(project.id, project) }
+  val result = repo.update(project.id, project)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return true when project is updated successfully`() {
+  val project1 = makeProject(UUID.randomUUID())
+  val project2 = makeProject(UUID.randomUUID())
+  val updatedProject = makeProject(project1.id)
+  every { dataSource.read() } returns listOf(project1, project2)
+  justRun { dataSource.update(project1.id, updatedProject) }
+  val result = repo.update(project1.id, updatedProject)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return false when delete a non existing project`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf()
+  val result = repo.delete(project.id)
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return true when delete an existing project`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  justRun { dataSource.delete(project.id) }
+  val result = repo.delete(project.id)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return false when project not exist`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf()
+  val result = repo.exists(project.id)
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return true when project exist`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  val result = repo.exists(project.id)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return project when project exist`() {
+  val project = makeProject(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  val result = repo.get(project.id)
+  assertThat(result).isEqualTo(project)
+ }
+
+ @Test
+ fun `should throw ProjectNotFoundException when project does not exist`() {
+  val nonExistentId = UUID.randomUUID()
+  every { dataSource.read() } returns listOf()
+  val exception = org.junit.jupiter.api.assertThrows<ProjectNotFoundException> {
+   repo.get(nonExistentId)
+  }
+  assertThat(exception.message).contains(nonExistentId.toString())
+ }
+
+ @Test
+ fun `should return empty list when no projects exist`() {
+  every { dataSource.read() } returns listOf()
+  val result = repo.getAll()
+  assertThat(result).isEmpty()
+ }
+
+ @Test
+ fun `should return list of projects when projects exist`() {
+  val project1 = makeProject(UUID.randomUUID())
+  val project2 = makeProject(UUID.randomUUID())
+  val twoProjects = listOf(project1, project2)
+  every { dataSource.read() } returns twoProjects
+  val result = repo.getAll()
+  assertThat(result).isEqualTo(twoProjects)
+ }
+
+ @Test
+ fun `should return false when assign mate to a project not exist`() {
+  val mate = makeMate(UUID.randomUUID())
+  every { dataSource.read() } returns listOf()
+  val result = repo.assignMate(UUID.randomUUID(), mate.id)
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return false when assign a mate already assigned to the project`() {
+  val project = makeProject(UUID.randomUUID())
+  val mate = makeMate(UUID.randomUUID())
+  project.assignedMatesIds.add(mate.id)
+  every { dataSource.read() } returns listOf(project)
+  val result = repo.assignMate(project.id, mate.id)
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return true when assign an existing mate to a new existing project`() {
+  val project = makeProject(UUID.randomUUID())
+  val mate = makeMate(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  justRun { dataSource.update(project.id, any()) }
+  val result = repo.assignMate(project.id, mate.id)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return true and save correct mapping when assigning mate`() {
+  val project1 = makeProject(UUID.randomUUID())
+  val project2 = makeProject(UUID.randomUUID())
+  val mate = makeMate(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project1, project2)
+  justRun { dataSource.update(project1.id, match { it.assignedMatesIds.contains(mate.id) }) }
+  val result = repo.assignMate(project1.id, mate.id)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return false when unassign mate to a project not exist`() {
+  every { dataSource.read() } returns listOf()
+  val result = repo.unassignMate(UUID.randomUUID(), UUID.randomUUID())
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return false when unassign a mate that isn't assigned to the project`() {
+  val project = makeProject(UUID.randomUUID())
+  val mate = makeMate(UUID.randomUUID())
+  every { dataSource.read() } returns listOf(project)
+  val result = repo.unassignMate(project.id, mate.id)
+  assertThat(result).isFalse()
+ }
+
+ @Test
+ fun `should return true when unassign an existing mate`() {
+  val project = makeProject(UUID.randomUUID())
+  val mate = makeMate(UUID.randomUUID())
+  project.assignedMatesIds.add(mate.id)
+  every { dataSource.read() } returns listOf(project)
+  justRun { dataSource.update(project.id, any()) }
+  val result = repo.unassignMate(project.id, mate.id)
+  assertThat(result).isTrue()
+ }
+
+ @Test
+ fun `should return true and save correct mapping when unassigning mate`() {
+  val mate = makeMate(UUID.randomUUID())
+  val project1 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mate.id) }
+  val project2 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(UUID.randomUUID()) }
+  every { dataSource.read() } returns listOf(project1, project2)
+  justRun { dataSource.update(project1.id, match { !it.assignedMatesIds.contains(mate.id) }) }
+  val result = repo.unassignMate(project1.id, mate.id)
+  assertThat(result).isTrue()
+ }
+
+}
+
+fun makeMate(mateID: UUID): Mate {
+ return Mate(mateID, "name", "password", Role.MATE)
+}
+
+fun makeProject(projectID: UUID): Project {
+ return Project(
+  projectID,
+  "name",
+  mutableListOf(),
+  LocalDateTime(2023, 10, 7, 3, 30, 0),
+ )
+}

--- a/src/test/kotlin/data/repo/ProjectRepositoryImplTest.kt
+++ b/src/test/kotlin/data/repo/ProjectRepositoryImplTest.kt
@@ -1,4 +1,3 @@
-
 package data.repo
 
 import io.mockk.mockk
@@ -20,219 +19,324 @@ import java.util.*
 class ProjectRepositoryImplTest {
 
 
- lateinit var dataSource: DataSource<Project>
- lateinit var repo: ProjectRepositoryImpl
+    lateinit var dataSource: DataSource<Project>
+    lateinit var repo: ProjectRepositoryImpl
 
- @BeforeEach
- fun setup() {
-  dataSource = mockk(relaxed = true)
-  repo = ProjectRepositoryImpl(dataSource)
- }
+    @BeforeEach
+    fun setup() {
+        dataSource = mockk(relaxed = true)
+        repo = ProjectRepositoryImpl(dataSource)
+    }
 
- @Test
- fun `should return false when create an existing project`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  justRun { dataSource.write(any<Project>()) }
-  val result = repo.create(project)
-  assertThat(result).isFalse()
-  verify(exactly = 0) { dataSource.write(any<Project>()) }
- }
+    @Test
+    fun `should return false when create an existing project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+        justRun { dataSource.write(any<Project>()) }
 
- @Test
- fun `should return true when create a new project`() {
-  val newProject = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf()
-  justRun { dataSource.write(newProject) }
-  val result = repo.create(newProject)
-  assertThat(result).isTrue()
-  verify { dataSource.write(newProject) }
- }
+        // When
+        val result = repo.create(project)
 
- @Test
- fun `should return false when update a non existing project`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf()
-  val result = repo.update(project.id, project)
-  assertThat(result).isFalse()
- }
+        // Then
+        assertThat(result).isFalse()
+        verify(exactly = 0) { dataSource.write(any<Project>()) }
+    }
 
- @Test
- fun `should return true when update an existing project`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  justRun { dataSource.update(project.id, project) }
-  val result = repo.update(project.id, project)
-  assertThat(result).isTrue()
- }
+    @Test
+    fun `should return true when create a new project`() {
+        // Given
+        val newProject = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf()
+        justRun { dataSource.write(newProject) }
 
- @Test
- fun `should return true when project is updated successfully`() {
-  val project1 = makeProject(UUID.randomUUID())
-  val project2 = makeProject(UUID.randomUUID())
-  val updatedProject = makeProject(project1.id)
-  every { dataSource.read() } returns listOf(project1, project2)
-  justRun { dataSource.update(project1.id, updatedProject) }
-  val result = repo.update(project1.id, updatedProject)
-  assertThat(result).isTrue()
- }
+        // When
+        val result = repo.create(newProject)
 
- @Test
- fun `should return false when delete a non existing project`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf()
-  val result = repo.delete(project.id)
-  assertThat(result).isFalse()
- }
+        // Then
+        assertThat(result).isTrue()
+        verify { dataSource.write(newProject) }
+    }
 
- @Test
- fun `should return true when delete an existing project`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  justRun { dataSource.delete(project.id) }
-  val result = repo.delete(project.id)
-  assertThat(result).isTrue()
- }
+    @Test
+    fun `should return false when update a non existing project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf()
 
- @Test
- fun `should return false when project not exist`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf()
-  val result = repo.exists(project.id)
-  assertThat(result).isFalse()
- }
+        // When
+        val result = repo.update(project.id, project)
 
- @Test
- fun `should return true when project exist`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  val result = repo.exists(project.id)
-  assertThat(result).isTrue()
- }
+        // Then
+        assertThat(result).isFalse()
+    }
 
- @Test
- fun `should return project when project exist`() {
-  val project = makeProject(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  val result = repo.get(project.id)
-  assertThat(result).isEqualTo(project)
- }
+    @Test
+    fun `should return true when update an existing project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+        justRun { dataSource.update(project.id, project) }
 
- @Test
- fun `should throw ProjectNotFoundException when project does not exist`() {
-  val nonExistentId = UUID.randomUUID()
-  every { dataSource.read() } returns listOf()
-  val exception = org.junit.jupiter.api.assertThrows<ProjectNotFoundException> {
-   repo.get(nonExistentId)
-  }
-  assertThat(exception.message).contains(nonExistentId.toString())
- }
+        // When
+        val result = repo.update(project.id, project)
 
- @Test
- fun `should return empty list when no projects exist`() {
-  every { dataSource.read() } returns listOf()
-  val result = repo.getAll()
-  assertThat(result).isEmpty()
- }
+        // Then
+        assertThat(result).isTrue()
+    }
 
- @Test
- fun `should return list of projects when projects exist`() {
-  val project1 = makeProject(UUID.randomUUID())
-  val project2 = makeProject(UUID.randomUUID())
-  val twoProjects = listOf(project1, project2)
-  every { dataSource.read() } returns twoProjects
-  val result = repo.getAll()
-  assertThat(result).isEqualTo(twoProjects)
- }
+    @Test
+    fun `should return true when project is updated successfully`() {
+        // Given
+        val project1 = makeProject(UUID.randomUUID())
+        val project2 = makeProject(UUID.randomUUID())
+        val updatedProject = makeProject(project1.id)
+        every { dataSource.read() } returns listOf(project1, project2)
+        justRun { dataSource.update(project1.id, updatedProject) }
 
- @Test
- fun `should return false when assign mate to a project not exist`() {
-  val mate = makeMate(UUID.randomUUID())
-  every { dataSource.read() } returns listOf()
-  val result = repo.assignMate(UUID.randomUUID(), mate.id)
-  assertThat(result).isFalse()
- }
+        // When
+        val result = repo.update(project1.id, updatedProject)
 
- @Test
- fun `should return false when assign a mate already assigned to the project`() {
-  val project = makeProject(UUID.randomUUID())
-  val mate = makeMate(UUID.randomUUID())
-  project.assignedMatesIds.add(mate.id)
-  every { dataSource.read() } returns listOf(project)
-  val result = repo.assignMate(project.id, mate.id)
-  assertThat(result).isFalse()
- }
+        // Then
+        assertThat(result).isTrue()
+    }
 
- @Test
- fun `should return true when assign an existing mate to a new existing project`() {
-  val project = makeProject(UUID.randomUUID())
-  val mate = makeMate(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  justRun { dataSource.update(project.id, any()) }
-  val result = repo.assignMate(project.id, mate.id)
-  assertThat(result).isTrue()
- }
+    @Test
+    fun `should return false when delete a non existing project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf()
 
- @Test
- fun `should return true and save correct mapping when assigning mate`() {
-  val project1 = makeProject(UUID.randomUUID())
-  val project2 = makeProject(UUID.randomUUID())
-  val mate = makeMate(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project1, project2)
-  justRun { dataSource.update(project1.id, match { it.assignedMatesIds.contains(mate.id) }) }
-  val result = repo.assignMate(project1.id, mate.id)
-  assertThat(result).isTrue()
- }
+        // When
+        val result = repo.delete(project.id)
 
- @Test
- fun `should return false when unassign mate to a project not exist`() {
-  every { dataSource.read() } returns listOf()
-  val result = repo.unassignMate(UUID.randomUUID(), UUID.randomUUID())
-  assertThat(result).isFalse()
- }
+        // Then
+        assertThat(result).isFalse()
+    }
 
- @Test
- fun `should return false when unassign a mate that isn't assigned to the project`() {
-  val project = makeProject(UUID.randomUUID())
-  val mate = makeMate(UUID.randomUUID())
-  every { dataSource.read() } returns listOf(project)
-  val result = repo.unassignMate(project.id, mate.id)
-  assertThat(result).isFalse()
- }
+    @Test
+    fun `should return true when delete an existing project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+        justRun { dataSource.delete(project.id) }
 
- @Test
- fun `should return true when unassign an existing mate`() {
-  val project = makeProject(UUID.randomUUID())
-  val mate = makeMate(UUID.randomUUID())
-  project.assignedMatesIds.add(mate.id)
-  every { dataSource.read() } returns listOf(project)
-  justRun { dataSource.update(project.id, any()) }
-  val result = repo.unassignMate(project.id, mate.id)
-  assertThat(result).isTrue()
- }
+        // When
+        val result = repo.delete(project.id)
 
- @Test
- fun `should return true and save correct mapping when unassigning mate`() {
-  val mate = makeMate(UUID.randomUUID())
-  val project1 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mate.id) }
-  val project2 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(UUID.randomUUID()) }
-  every { dataSource.read() } returns listOf(project1, project2)
-  justRun { dataSource.update(project1.id, match { !it.assignedMatesIds.contains(mate.id) }) }
-  val result = repo.unassignMate(project1.id, mate.id)
-  assertThat(result).isTrue()
- }
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `should return false when project not exist`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf()
+
+        // When
+        val result = repo.exists(project.id)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return true when project exist`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+
+        // When
+        val result = repo.exists(project.id)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `should return project when project exist`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+
+        // When
+        val result = repo.get(project.id)
+
+        // Then
+        assertThat(result).isEqualTo(project)
+    }
+
+    @Test
+    fun `should throw ProjectNotFoundException when project does not exist`() {
+        // Given
+        val nonExistentId = UUID.randomUUID()
+        every { dataSource.read() } returns listOf()
+
+        // When
+        val exception = org.junit.jupiter.api.assertThrows<ProjectNotFoundException> {
+            repo.get(nonExistentId)
+        }
+
+        // Then
+        assertThat(exception.message).contains(nonExistentId.toString())
+    }
+
+    @Test
+    fun `should return empty list when no projects exist`() {
+        // Given
+        every { dataSource.read() } returns listOf()
+
+        // When
+        val result = repo.getAll()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should return list of projects when projects exist`() {
+        // Given
+        val project1 = makeProject(UUID.randomUUID())
+        val project2 = makeProject(UUID.randomUUID())
+        val twoProjects = listOf(project1, project2)
+        every { dataSource.read() } returns twoProjects
+
+        // When
+        val result = repo.getAll()
+
+        // Then
+        assertThat(result).isEqualTo(twoProjects)
+    }
+
+    @Test
+    fun `should return false when assign mate to a project not exist`() {
+        // Given
+        val mate = makeMate(UUID.randomUUID())
+        every { dataSource.read() } returns listOf()
+
+        // When
+        val result = repo.assignMate(UUID.randomUUID(), mate.id)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return false when assign a mate already assigned to the project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        val mate = makeMate(UUID.randomUUID())
+        project.assignedMatesIds.add(mate.id)
+        every { dataSource.read() } returns listOf(project)
+
+        // When
+        val result = repo.assignMate(project.id, mate.id)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return true when assign an existing mate to a new existing project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        val mate = makeMate(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+        justRun { dataSource.update(project.id, any()) }
+
+        // When
+        val result = repo.assignMate(project.id, mate.id)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `should return true and save correct mapping when assigning mate`() {
+        // Given
+        val project1 = makeProject(UUID.randomUUID())
+        val project2 = makeProject(UUID.randomUUID())
+        val mate = makeMate(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project1, project2)
+        justRun { dataSource.update(project1.id, match { it.assignedMatesIds.contains(mate.id) }) }
+
+        // When
+        val result = repo.assignMate(project1.id, mate.id)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `should return false when unassign mate to a project not exist`() {
+        // Given
+        every { dataSource.read() } returns listOf()
+
+        // When
+        val result = repo.unassignMate(UUID.randomUUID(), UUID.randomUUID())
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return false when unassign a mate that isn't assigned to the project`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        val mate = makeMate(UUID.randomUUID())
+        every { dataSource.read() } returns listOf(project)
+
+        // When
+        val result = repo.unassignMate(project.id, mate.id)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return true when unassign an existing mate`() {
+        // Given
+        val project = makeProject(UUID.randomUUID())
+        val mate = makeMate(UUID.randomUUID())
+        project.assignedMatesIds.add(mate.id)
+        every { dataSource.read() } returns listOf(project)
+        justRun { dataSource.update(project.id, any()) }
+
+        // When
+        val result = repo.unassignMate(project.id, mate.id)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `should return true and save correct mapping when unassigning mate`() {
+        // Given
+        val mate = makeMate(UUID.randomUUID())
+        val project1 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mate.id) }
+        val project2 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(UUID.randomUUID()) }
+        every { dataSource.read() } returns listOf(project1, project2)
+        justRun { dataSource.update(project1.id, match { !it.assignedMatesIds.contains(mate.id) }) }
+
+        // When
+        val result = repo.unassignMate(project1.id, mate.id)
+
+        // Then
+        assertThat(result).isTrue()
+    }
 
 }
 
 fun makeMate(mateID: UUID): Mate {
- return Mate(mateID, "name", "password", Role.MATE)
+    return Mate(mateID, "name", "password", Role.MATE)
 }
 
 fun makeProject(projectID: UUID): Project {
- return Project(
-  projectID,
-  "name",
-  mutableListOf(),
-  LocalDateTime(2023, 10, 7, 3, 30, 0),
- )
+    return Project(
+        projectID,
+        "name",
+        mutableListOf(),
+        LocalDateTime(2023, 10, 7, 3, 30, 0),
+    )
 }

--- a/src/test/kotlin/data/repo/ProjectRepositoryImplTest.kt
+++ b/src/test/kotlin/data/repo/ProjectRepositoryImplTest.kt
@@ -2,7 +2,6 @@ package data.repo
 
 import io.mockk.mockk
 import logic.model.Project
-import logic.model.Mate
 import org.damascus.data.DataSource
 import org.damascus.data.repo.ProjectRepositoryImpl
 import com.google.common.truth.Truth.assertThat
@@ -10,9 +9,8 @@ import kotlinx.datetime.LocalDateTime
 import org.damascus.data.repo.ProjectNotFoundException
 import org.junit.jupiter.api.Test
 import io.mockk.every
-import io.mockk.justRun
+import org.junit.jupiter.api.assertThrows
 import io.mockk.verify
-import org.damascus.logic.model.Role
 import org.junit.jupiter.api.BeforeEach
 import java.util.*
 
@@ -29,11 +27,10 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return false when create an existing project`() {
+    fun `create function should return false when create an existing project`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf(project)
-        justRun { dataSource.write(any<Project>()) }
 
         // When
         val result = repo.create(project)
@@ -44,11 +41,10 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return true when create a new project`() {
+    fun `create function should return true when create a new project`() {
         // Given
         val newProject = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf()
-        justRun { dataSource.write(newProject) }
 
         // When
         val result = repo.create(newProject)
@@ -59,7 +55,7 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return false when update a non existing project`() {
+    fun `update function should return false when update a non existing project`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf()
@@ -72,27 +68,12 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return true when update an existing project`() {
-        // Given
-        val project = makeProject(UUID.randomUUID())
-        every { dataSource.read() } returns listOf(project)
-        justRun { dataSource.update(project.id, project) }
-
-        // When
-        val result = repo.update(project.id, project)
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `should return true when project is updated successfully`() {
+    fun `update function should return true when project is updated successfully`() {
         // Given
         val project1 = makeProject(UUID.randomUUID())
         val project2 = makeProject(UUID.randomUUID())
         val updatedProject = makeProject(project1.id)
         every { dataSource.read() } returns listOf(project1, project2)
-        justRun { dataSource.update(project1.id, updatedProject) }
 
         // When
         val result = repo.update(project1.id, updatedProject)
@@ -102,7 +83,7 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return false when delete a non existing project`() {
+    fun `delete function should return false when delete a non existing project`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf()
@@ -115,11 +96,10 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return true when delete an existing project`() {
+    fun `delete function should return true when delete an existing project`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf(project)
-        justRun { dataSource.delete(project.id) }
 
         // When
         val result = repo.delete(project.id)
@@ -129,7 +109,7 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return false when project not exist`() {
+    fun `exists function should return false when project not exist`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf()
@@ -142,7 +122,7 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return true when project exist`() {
+    fun `exists function should return true when project exist`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf(project)
@@ -155,7 +135,7 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return project when project exist`() {
+    fun `get function should return project when project exist`() {
         // Given
         val project = makeProject(UUID.randomUUID())
         every { dataSource.read() } returns listOf(project)
@@ -168,22 +148,19 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should throw ProjectNotFoundException when project does not exist`() {
+    fun `get should throw ProjectNotFoundException when project does not exist`() {
         // Given
         val nonExistentId = UUID.randomUUID()
         every { dataSource.read() } returns listOf()
 
-        // When
-        val exception = org.junit.jupiter.api.assertThrows<ProjectNotFoundException> {
+        // When & Then
+        assertThrows<ProjectNotFoundException> {
             repo.get(nonExistentId)
         }
-
-        // Then
-        assertThat(exception.message).contains(nonExistentId.toString())
     }
 
     @Test
-    fun `should return empty list when no projects exist`() {
+    fun `getAll function should return empty list when no projects exist`() {
         // Given
         every { dataSource.read() } returns listOf()
 
@@ -195,7 +172,7 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return list of projects when projects exist`() {
+    fun `getAll function should return list of projects when projects exist`() {
         // Given
         val project1 = makeProject(UUID.randomUUID())
         val project2 = makeProject(UUID.randomUUID())
@@ -210,131 +187,67 @@ class ProjectRepositoryImplTest {
     }
 
     @Test
-    fun `should return false when assign mate to a project not exist`() {
+    fun `getAllProjectsByMateId function should return empty list when no projects are assigned to the mate`() {
         // Given
-        val mate = makeMate(UUID.randomUUID())
+        val mateId = UUID.randomUUID()
         every { dataSource.read() } returns listOf()
 
         // When
-        val result = repo.assignMate(UUID.randomUUID(), mate.id)
+        val result = repo.getAllProjectsByMateId(mateId)
 
         // Then
-        assertThat(result).isFalse()
+        assertThat(result).isEmpty()
     }
 
     @Test
-    fun `should return false when assign a mate already assigned to the project`() {
+    fun `getAllProjectsByMateId function should return a list of projects assigned to the mate`() {
         // Given
-        val project = makeProject(UUID.randomUUID())
-        val mate = makeMate(UUID.randomUUID())
-        project.assignedMatesIds.add(mate.id)
-        every { dataSource.read() } returns listOf(project)
-
-        // When
-        val result = repo.assignMate(project.id, mate.id)
-
-        // Then
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `should return true when assign an existing mate to a new existing project`() {
-        // Given
-        val project = makeProject(UUID.randomUUID())
-        val mate = makeMate(UUID.randomUUID())
-        every { dataSource.read() } returns listOf(project)
-        justRun { dataSource.update(project.id, any()) }
-
-        // When
-        val result = repo.assignMate(project.id, mate.id)
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `should return true and save correct mapping when assigning mate`() {
-        // Given
-        val project1 = makeProject(UUID.randomUUID())
-        val project2 = makeProject(UUID.randomUUID())
-        val mate = makeMate(UUID.randomUUID())
+        val mateId = UUID.randomUUID()
+        val project1 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mateId) }
+        val project2 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mateId) }
         every { dataSource.read() } returns listOf(project1, project2)
-        justRun { dataSource.update(project1.id, match { it.assignedMatesIds.contains(mate.id) }) }
 
         // When
-        val result = repo.assignMate(project1.id, mate.id)
+        val result = repo.getAllProjectsByMateId(mateId)
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).containsExactly(project1, project2)
     }
 
     @Test
-    fun `should return false when unassign mate to a project not exist`() {
+    fun `getAllProjectsByMateId function should return empty list when no project contains the mate`() {
         // Given
-        every { dataSource.read() } returns listOf()
-
-        // When
-        val result = repo.unassignMate(UUID.randomUUID(), UUID.randomUUID())
-
-        // Then
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `should return false when unassign a mate that isn't assigned to the project`() {
-        // Given
-        val project = makeProject(UUID.randomUUID())
-        val mate = makeMate(UUID.randomUUID())
-        every { dataSource.read() } returns listOf(project)
-
-        // When
-        val result = repo.unassignMate(project.id, mate.id)
-
-        // Then
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `should return true when unassign an existing mate`() {
-        // Given
-        val project = makeProject(UUID.randomUUID())
-        val mate = makeMate(UUID.randomUUID())
-        project.assignedMatesIds.add(mate.id)
-        every { dataSource.read() } returns listOf(project)
-        justRun { dataSource.update(project.id, any()) }
-
-        // When
-        val result = repo.unassignMate(project.id, mate.id)
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `should return true and save correct mapping when unassigning mate`() {
-        // Given
-        val mate = makeMate(UUID.randomUUID())
-        val project1 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mate.id) }
-        val project2 = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(UUID.randomUUID()) }
+        val mateId = UUID.randomUUID()
+        val project1 = makeProject(UUID.randomUUID()) // Mate is not assigned
+        val project2 = makeProject(UUID.randomUUID()) // Mate is not assigned
         every { dataSource.read() } returns listOf(project1, project2)
-        justRun { dataSource.update(project1.id, match { !it.assignedMatesIds.contains(mate.id) }) }
 
         // When
-        val result = repo.unassignMate(project1.id, mate.id)
+        val result = repo.getAllProjectsByMateId(mateId)
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `getAllProjectsByMateId should read from dataSource`() {
+        // Given
+        val mateId = UUID.randomUUID()
+        val project = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mateId) }
+        every { dataSource.read() } returns listOf(project)
+
+        // When
+        repo.getAllProjectsByMateId(mateId)
+
+        // Then
+        verify { dataSource.read() }
     }
 
 }
 
-fun makeMate(mateID: UUID): Mate {
-    return Mate(mateID, "name", "password", Role.MATE)
-}
-
-fun makeProject(projectID: UUID): Project {
+fun makeProject(id: UUID): Project {
     return Project(
-        projectID,
+        id = id,
         "name",
         mutableListOf(),
         LocalDateTime(2023, 10, 7, 3, 30, 0),

--- a/src/test/kotlin/logic/usecase/ModifyMateAssignmentUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecase/ModifyMateAssignmentUseCaseTest.kt
@@ -1,0 +1,119 @@
+package logic.usecase
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.datetime.LocalDateTime
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+import org.damascus.logic.usecase.ModifyMateAssignmentUseCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class ModifyMateAssignmentUseCaseTest {
+
+    private lateinit var repository: ProjectRepository
+    private lateinit var useCase: ModifyMateAssignmentUseCase
+
+    @BeforeEach
+    fun setup() {
+        repository = mockk(relaxed = true)
+        useCase = ModifyMateAssignmentUseCase(repository)
+    }
+
+    @Test
+    fun `should return false when assigning mate to non-existing project`() {
+        // Given
+        every { repository.get(any()) } throws Exception()
+
+        // When
+        val result = useCase(UUID.randomUUID(), UUID.randomUUID(), shouldAssign = true)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return false when assigning mate already assigned`() {
+        // Given
+        val mateId = UUID.randomUUID()
+        val project = makeProject().apply { assignedMatesIds.add(mateId) }
+        every { repository.get(project.id) } returns project
+
+        // When
+        val result = useCase(project.id, mateId, shouldAssign = true)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return true when assigning mate not yet assigned`() {
+        // Given
+        val mateId = UUID.randomUUID()
+        val project = makeProject()
+        every { repository.get(project.id) } returns project
+        every { repository.update(any(), any()) } returns true
+
+        // When
+        val result = useCase(project.id, mateId, shouldAssign = true)
+
+        // Then
+        assertThat(result).isTrue()
+        verify { repository.update(project.id, match { mateId in it.assignedMatesIds }) }
+    }
+
+    @Test
+    fun `should return false when unassigning mate from non-existing project`() {
+        // Given
+        every { repository.get(any()) } throws Exception()
+
+        // When
+        val result = useCase(UUID.randomUUID(), UUID.randomUUID(), shouldAssign = false)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return false when unassigning mate not in list`() {
+        // Given
+        val project = makeProject()
+        val mateId = UUID.randomUUID()
+        every { repository.get(project.id) } returns project
+
+        // When
+        val result = useCase(project.id, mateId, shouldAssign = false)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `should return true when unassigning an existing mate`() {
+        // Given
+        val mateId = UUID.randomUUID()
+        val project = makeProject().apply { assignedMatesIds.add(mateId) }
+        every { repository.get(project.id) } returns project
+        every { repository.update(any(), any()) } returns true
+
+        // When
+        val result = useCase(project.id, mateId, shouldAssign = false)
+
+        // Then
+        assertThat(result).isTrue()
+        verify { repository.update(project.id, match { mateId !in it.assignedMatesIds }) }
+    }
+
+    private fun makeProject(id: UUID = UUID.randomUUID()): Project {
+        return Project(
+            id = id,
+            name = "Dummy",
+            assignedMatesIds = mutableListOf(),
+            creationDate = LocalDateTime(2023, 10, 7, 3, 30, 0)
+        )
+    }
+
+}

--- a/src/test/kotlin/logic/usecase/ModifyMateAssignmentUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecase/ModifyMateAssignmentUseCaseTest.kt
@@ -7,7 +7,7 @@ import io.mockk.verify
 import kotlinx.datetime.LocalDateTime
 import logic.model.Project
 import org.damascus.logic.repository.ProjectRepository
-import org.damascus.logic.usecase.ModifyMateAssignmentUseCase
+import org.damascus.logic.usecase.ProjectUseCase.ModifyMateAssignmentUseCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*

--- a/src/test/kotlin/logic/usecase/ProjectUseCase/ProjectUseCasesTest.kt
+++ b/src/test/kotlin/logic/usecase/ProjectUseCase/ProjectUseCasesTest.kt
@@ -1,0 +1,157 @@
+package logic.usecase.project
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.datetime.LocalDateTime
+import logic.model.Project
+import org.damascus.logic.repository.ProjectRepository
+import org.damascus.logic.usecase.ProjectUseCase.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class ProjectUseCasesTest {
+
+    lateinit var repository: ProjectRepository
+    lateinit var project: Project
+
+    @BeforeEach
+    fun setup() {
+        repository = mockk(relaxed = true)
+        project = makeProject(UUID.randomUUID())
+    }
+
+    @Test
+    fun `create use case should return false if project already exists`() {
+        every { repository.exists(project.id) } returns true
+
+        val result = CreateProjectUseCase(repository).invoke(project)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `create use case should return true if project is new`() {
+        every { repository.exists(project.id) } returns false
+        every { repository.create(project) } returns true
+
+        val result = CreateProjectUseCase(repository).invoke(project)
+
+        assertThat(result).isTrue()
+        verify { repository.create(project) }
+    }
+
+    @Test
+    fun `update use case should return true if project updated`() {
+        every { repository.update(project.id, project) } returns true
+
+        val result = UpdateProjectUseCase(repository).invoke(project.id, project)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `update use case should return false if project does not exist`() {
+        every { repository.update(project.id, project) } returns false
+
+        val result = UpdateProjectUseCase(repository).invoke(project.id, project)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `delete use case should return true when deletion is successful`() {
+        every { repository.delete(project.id) } returns true
+
+        val result = DeleteProjectUseCase(repository).invoke(project.id)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `delete use case should return false when project does not exist`() {
+        every { repository.delete(project.id) } returns false
+
+        val result = DeleteProjectUseCase(repository).invoke(project.id)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `get project use case should return correct project`() {
+        every { repository.get(project.id) } returns project
+
+        val result = GetProjectUseCase(repository).invoke(project.id)
+
+        assertThat(result).isEqualTo(project)
+    }
+
+    @Test
+    fun `get all projects use case should return list of projects`() {
+        val project2 = makeProject(UUID.randomUUID())
+        every { repository.getAll() } returns listOf(project, project2)
+
+        val result = GetAllProjectsUseCase(repository).invoke()
+
+        assertThat(result).containsExactly(project, project2)
+    }
+
+    @Test
+    fun `get all projects use case should return empty list when no projects exist`() {
+        every { repository.getAll() } returns listOf()
+
+        val result = GetAllProjectsUseCase(repository).invoke()
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `get all projects by mate id should return list of matching projects`() {
+        val mateId = UUID.randomUUID()
+        val projectWithMate = makeProject(UUID.randomUUID()).apply { assignedMatesIds.add(mateId) }
+        every { repository.getAllProjectsByMateId(mateId) } returns listOf(projectWithMate)
+
+        val result = GetAllProjectsByMateIdUseCase(repository).invoke(mateId)
+
+        assertThat(result).containsExactly(projectWithMate)
+    }
+
+    @Test
+    fun `get all projects by mate id should return empty list if no matches`() {
+        val mateId = UUID.randomUUID()
+        every { repository.getAllProjectsByMateId(mateId) } returns listOf()
+
+        val result = GetAllProjectsByMateIdUseCase(repository).invoke(mateId)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `check project exists use case should return true if project exists`() {
+        every { repository.exists(project.id) } returns true
+
+        val result = CheckProjectExistsUseCase(repository).invoke(project.id)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `check project exists use case should return false if project does not exist`() {
+        every { repository.exists(project.id) } returns false
+
+        val result = CheckProjectExistsUseCase(repository).invoke(project.id)
+
+        assertThat(result).isFalse()
+    }
+}
+
+fun makeProject(id: UUID): Project {
+    return Project(
+        id = id,
+        name = "Test Project",
+        assignedMatesIds = mutableListOf(),
+        creationDate = LocalDateTime(2023, 10, 7, 3, 30, 0)
+    )
+}


### PR DESCRIPTION
## Add Project Repository Interface with implementation and unit tests

This PR introduces the implementation of the Project Manipulation feature, including:

-  **Interface**: `ProjectRepository` defines the interface for project persistence and mate assignment operations.
    
-  **Implementation**: `ProjectRepositoryImpl` backed by a generic `DataSource<Project>`, with robust logic for:
    - Creating, updating, deleting, and retrieving projects
    - Assigning and unassigning mates to projects
    - Existence checks and error handling with `ProjectNotFoundException`
        
-  **Unit Tests**: Thorough test suite for all repository methods using MockK and Truth, including :
    - Test coverage includes edge cases and ensures data consistency
    - **Test-Driven Development (TDD)** approach: all functionality was written based on previously defined failing tests
    closes #4 
        
